### PR TITLE
Fix extension issue when checkin if file exists

### DIFF
--- a/routes/user/index.js
+++ b/routes/user/index.js
@@ -4,19 +4,15 @@ const express = require('express');
 const router = express.Router();
 const {log} = require('../lib');
 
-
 router.get('/:page', (req, res) => {
-  return exists(
-    resolve(join(__dirname, '..', '..', 'views', 'user', req.params.page)),
-    ok => {
-      if (ok) {
-        res.render(join('user', req.params.page),
-          {title: 'Final Year CO600 Project', user: req.session.user});
-      } else {
-        log.warn(
-          `the ${req.params.page} user page has not been created yet (hint: you can create "/views/user/${req.params.page}.hbs" and it will be served)`);
-      }
-    });
+  const pagePath = resolve(join(__dirname, '..', '..', 'views', 'user', `${req.params.page}.hbs`));
+  return exists(pagePath, ok => {
+    if (ok) {
+      return res.render(join('user', req.params.page), {title: 'Final Year CO600 Project', email: req.cookies.email});
+    } 
+    log.warn(`the file ${pagePath} does not exist`);
+    log.warn(`the ${req.params.page} user page has not been created yet (hint: you can create "/views/user/${req.params.page}.hbs" and it will be served)`);
+  });
 });
 
 router.get('/', (req, res) => res.redirect('/user/profile'));


### PR DESCRIPTION
I wasn't looking at the extension when checking if an `*.hbs` file exists. This should fix it.